### PR TITLE
added absorption fraction metric

### DIFF
--- a/sae_bench/evals/absorption/README.md
+++ b/sae_bench/evals/absorption/README.md
@@ -1,4 +1,8 @@
-This repo implements David Chanin's feature absorption metric.
+This repo implements David Chanin's feature absorption metric, with the absorption fraction metric added by Demian Till.
+
+The code produces two scores:
+- `mean_absorption_fraction_score` captures both full and partial absorption with an arbitrary number of absorbing latents. For a given SAE input, the absorption fraction is essentially the fraction of the SAE reconstruction's projection onto the ground truth probe activation that is not accounted for by the main latents which usually represent the feature in question.
+- `mean_full_absorption_score` captures full absorption (not partial absorption) with a single absorbing latent. For a given SAE input, full absorption is judged to occur when the feature is present according to the ground truth probe, the main latents usually representing that feature have zero activation, and another latent compensates with a projection onto the ground truth probe direction which is above a set threshold as a proportion of the ground truth probe activation.
 
 Estimated runtime:
 

--- a/sae_bench/evals/absorption/eval_output.py
+++ b/sae_bench/evals/absorption/eval_output.py
@@ -1,3 +1,4 @@
+from pydantic.dataclasses import dataclass
 from pydantic import ConfigDict, Field, field_validator
 from sae_bench.evals.absorption.eval_config import AbsorptionEvalConfig
 from sae_bench.evals.base_eval_output import (

--- a/sae_bench/evals/absorption/eval_output.py
+++ b/sae_bench/evals/absorption/eval_output.py
@@ -1,4 +1,3 @@
-from pydantic.dataclasses import dataclass
 from pydantic import ConfigDict, Field, field_validator
 from sae_bench.evals.absorption.eval_config import AbsorptionEvalConfig
 from sae_bench.evals.base_eval_output import (
@@ -15,10 +14,14 @@ EVAL_TYPE_ID_ABSORPTION = "absorption_first_letter"
 # Define the metrics for each metric category, and include a title and description for each.
 @dataclass
 class AbsorptionMeanMetrics(BaseMetrics):
-
-    mean_absorption_score: float = Field(
-        title="Mean Absorption Score",
-        description="Average of the absorption scores across all letters",
+    mean_absorption_fraction_score: float = Field(
+        title="Mean Absorption Fraction Score",
+        description="Average of the absorption fraction scores across all letters",
+        json_schema_extra=DEFAULT_DISPLAY,
+    )
+    mean_full_absorption_score: float = Field(
+        title="Mean Full Absorption Score",
+        description="Average of the full absorption scores across all letters",
         json_schema_extra=DEFAULT_DISPLAY,
     )
     mean_num_split_features: float = Field(
@@ -51,8 +54,13 @@ class AbsorptionResultDetail(BaseResultDetail):
             return value
         raise ValueError("First letter must be a single letter")
 
-    absorption_rate: float = Field(title="Absorption Rate", description="")
-    num_absorption: int = Field(title="Num Absorption", description="")
+    mean_absorption_fraction: float = Field(
+        title="Mean Absorption Fraction", description=""
+    )
+    full_absorption_rate: float = Field(
+        title="Rate of Full Absorption", description=""
+    )
+    num_full_absorption: int = Field(title="Num Full Absorption", description="")
     num_probe_true_positives: int = Field(
         title="Num Probe True Positives", description=""
     )

--- a/sae_bench/evals/absorption/feature_absorption.py
+++ b/sae_bench/evals/absorption/feature_absorption.py
@@ -99,7 +99,8 @@ def calculate_projection_and_cos_sims(
                     score.probe_cos_sim
                     for score in sample.top_projection_feature_scores
                 ],
-                "is_absorption": sample.is_absorption,
+                "absorption_fraction": sample.absorption_fraction,
+                "is_full_absorption": sample.is_full_absorption,
             }
             results.append(result)
     result_df = pd.DataFrame(results)
@@ -131,7 +132,6 @@ def get_stats_and_likely_false_negative_tokens(
         potential_false_negatives = raw_df[
             (raw_df["answer_letter"] == letter)
             & (raw_df[f"score_probe_{letter}"] > 0)
-            & (raw_df[f"score_sparse_sae_{letter}_k_{k}"] <= 0)
         ]["token"].tolist()
         num_split_feats_true_positives = raw_df[
             (raw_df["answer_letter"] == letter)

--- a/sae_bench/evals/absorption/feature_absorption_calculator.py
+++ b/sae_bench/evals/absorption/feature_absorption_calculator.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+import numpy as np
 import torch
 from sae_lens import SAE
 from tqdm.autonotebook import tqdm
@@ -34,7 +35,8 @@ class WordAbsorptionResult:
     probe_projection: float
     main_feature_scores: list[FeatureScore]
     top_projection_feature_scores: list[FeatureScore]
-    is_absorption: bool
+    absorption_fraction: float
+    is_full_absorption: bool
 
 
 @dataclass
@@ -116,7 +118,7 @@ class FeatureAbsorptionCalculator:
             for word in words
         ]
 
-    def _is_absorption(
+    def _is_full_absorption(
         self,
         probe_projection: float,
         main_feature_scores: list[FeatureScore],
@@ -150,19 +152,18 @@ class FeatureAbsorptionCalculator:
         probe_direction: torch.Tensor,
         main_feature_ids: list[int],
         layer: int,
-        filter_prompts: bool = True,
+        filter_prompts: bool = False,
         show_progress: bool = True,
     ) -> AbsorptionResults:
         """
-        This method calculates the absorption for each word in the list of words. If `max_ablation_samples` is provided,
-        this method will randomly sample that many words to calculate absorption for as a performance optimization.
-        If `filter_prompts` is True, this method will filter out any prompts where the main features are already active, as these cannot be absorption.
+        This method calculates the absorption for each word in the list of words
         """
         if probe_direction.ndim != 1:
             raise ValueError("probe_direction must be 1D")
         # make sure the probe direction is a unit vector
         probe_direction = probe_direction / probe_direction.norm()
         prompts = self._build_prompts(words)
+        self._validate_prompts_are_same_length(prompts)
         if filter_prompts:
             prompts = self._filter_prompts(prompts, sae, main_feature_ids)
         results: list[WordAbsorptionResult] = []
@@ -190,6 +191,21 @@ class FeatureAbsorptionCalculator:
                 sae_acts = batch_sae_acts[i]
                 act_probe_proj = batch_probe_projections[i].cpu().item()
                 sae_act_probe_proj = batch_sae_probe_projections[i]
+
+                # calculate absorption_fraction
+                main_feats_probe_proj = (
+                    torch.sum(sae_act_probe_proj[main_feature_ids]).cpu().item()
+                )
+                all_feats_probe_proj = torch.sum(sae_act_probe_proj).cpu().item()
+                if main_feats_probe_proj >= act_probe_proj or all_feats_probe_proj <= 0:
+                    absorption_fraction = 0.0
+                else:
+                    absorption_fraction = (
+                        all_feats_probe_proj - main_feats_probe_proj
+                    ) / all_feats_probe_proj
+                    absorption_fraction = np.clip(absorption_fraction, 0.0, 1.0)
+
+                # determine whether this is full absorption with a single absorbing latent
                 with torch.inference_mode():
                     # sort by negative ig score
                     top_proj_feats = sae_act_probe_proj.topk(
@@ -205,21 +221,23 @@ class FeatureAbsorptionCalculator:
                         probe_cos_sims=cos_sims,
                         sae_acts=sae_acts,
                     )
-                    is_absorption = self._is_absorption(
+                    is_full_absorption = self._is_full_absorption(
                         probe_projection=act_probe_proj,
                         top_projection_feature_scores=top_projection_feature_scores,
                         main_feature_scores=main_feature_scores,
                     )
-                    results.append(
-                        WordAbsorptionResult(
-                            word=prompt.word,
-                            prompt=prompt.base,
-                            probe_projection=act_probe_proj,
-                            main_feature_scores=main_feature_scores,
-                            top_projection_feature_scores=top_projection_feature_scores,
-                            is_absorption=is_absorption,
-                        )
+
+                results.append(
+                    WordAbsorptionResult(
+                        word=prompt.word,
+                        prompt=prompt.base,
+                        probe_projection=act_probe_proj,
+                        main_feature_scores=main_feature_scores,
+                        top_projection_feature_scores=top_projection_feature_scores,
+                        absorption_fraction=absorption_fraction,
+                        is_full_absorption=is_full_absorption,
                     )
+                )
         return AbsorptionResults(
             main_feature_ids=main_feature_ids,
             word_results=results,

--- a/sae_bench/evals/absorption/probing.py
+++ b/sae_bench/evals/absorption/probing.py
@@ -475,12 +475,12 @@ def gen_probe_stats(
 
     def validator_fn(x: torch.Tensor) -> torch.Tensor:
         logits = probe(x.clone().detach().to(device))
-        return (logits > threshold).float().cpu()
+        return (logits > threshold).float().cpu().numpy()
 
     results: list[ProbeStats] = []
 
     val_preds = validator_fn(X_val)
-    y_val_cpu = y_val.cpu()
+    y_val_cpu = y_val.cpu().numpy()
 
     for i, letter in enumerate(LETTERS):
         letter_preds = (val_preds[:, i]).cpu().numpy()

--- a/sae_bench/evals/absorption/probing.py
+++ b/sae_bench/evals/absorption/probing.py
@@ -475,12 +475,12 @@ def gen_probe_stats(
 
     def validator_fn(x: torch.Tensor) -> torch.Tensor:
         logits = probe(x.clone().detach().to(device))
-        return (logits > threshold).float().cpu().numpy()
+        return (logits > threshold).float().cpu()
 
     results: list[ProbeStats] = []
 
     val_preds = validator_fn(X_val)
-    y_val_cpu = y_val.cpu().numpy()
+    y_val_cpu = y_val.cpu()
 
     for i, letter in enumerate(LETTERS):
         letter_preds = (val_preds[:, i]).cpu().numpy()

--- a/tests/acceptance/test_absorption.py
+++ b/tests/acceptance/test_absorption.py
@@ -65,18 +65,22 @@ def test_end_to_end_different_seed():
 
     # Find the correct key in the new structure
     actual_result_key = f"{TEST_RELEASE}_{TEST_SAE_NAME}"
-    actual_mean_absorption_rate = run_results[actual_result_key]["eval_result_metrics"][
-        "mean"
-    ]["mean_absorption_score"]
+    actual_mean_absorption_fraction_rate = run_results[actual_result_key]["eval_result_metrics"]["mean"][
+        "mean_absorption_fraction_score"
+    ]
+    actual_mean_full_absorption_rate = run_results[actual_result_key]["eval_result_metrics"]["mean"][
+        "mean_full_absorption_score"
+    ]
 
     # Load expected results and compare
     with open(expected_results_filename, "r") as f:
         expected_results = json.load(f)
 
-    expected_mean_absorption_rate = expected_results["eval_result_metrics"]["mean"][
-        "mean_absorption_score"
+    expected_mean_absorption_fraction_rate = expected_results["eval_result_metrics"]["mean"][
+        "mean_absorption_fraction_score"
     ]
-    assert (
-        abs(actual_mean_absorption_rate - expected_mean_absorption_rate)
-        < TEST_TOLERANCE
-    )
+    expected_mean_full_absorption_rate = expected_results["eval_result_metrics"]["mean"][
+        "mean_full_absorption_score"
+    ]
+    assert abs(actual_mean_full_absorption_rate - expected_mean_full_absorption_rate) < TEST_TOLERANCE
+    assert abs(actual_mean_absorption_fraction_rate - expected_mean_absorption_fraction_rate) < TEST_TOLERANCE

--- a/tests/acceptance/test_data/absorption/absorption_expected_results.json
+++ b/tests/acceptance/test_data/absorption/absorption_expected_results.json
@@ -1,207 +1,268 @@
 {
   "eval_type_id": "absorption_first_letter",
   "eval_config": {
-    "random_seed": 42,
+    "model_name": "pythia-70m-deduped",
+    "random_seed": 44,
     "f1_jump_threshold": 0.03,
     "max_k_value": 10,
     "prompt_template": "{word} has the first letter:",
     "prompt_token_pos": -6,
-    "model_name": "pythia-70m-deduped"
+    "llm_batch_size": 512,
+    "llm_dtype": "float32",
+    "k_sparse_probe_l1_decay": 0.01,
+    "k_sparse_probe_batch_size": 4096,
+    "k_sparse_probe_num_epochs": 50
   },
-  "eval_id": "0700eec8-f35d-4d1f-a7d2-ad40d6cefc74",
-  "datetime_epoch_millis": 1729878630066,
+  "eval_id": "7c984955-4272-4725-97d5-3290e16075e4",
+  "datetime_epoch_millis": 1736525368764,
   "eval_result_metrics": {
     "mean": {
-      "mean_absorption_score": 0.19134957744052783,
-      "mean_num_split_features": 1.1153846153846154
+      "mean_absorption_fraction_score": 0.6474364483115522,
+      "mean_full_absorption_score": 0.2541845540833111,
+      "mean_num_split_features": 1.1923076923076923
     }
   },
   "eval_result_details": [
     {
       "first_letter": "a",
-      "absorption_rate": 0.09076682316118936,
-      "num_absorption": 58,
-      "num_probe_true_positives": 639,
+      "mean_absorption_fraction": 0.6271904319193522,
+      "full_absorption_rate": 0.26605504587155965,
+      "num_full_absorption": 174,
+      "num_probe_true_positives": 654,
       "num_split_features": 1
     },
     {
       "first_letter": "b",
-      "absorption_rate": 0.17940199335548174,
-      "num_absorption": 54,
-      "num_probe_true_positives": 301,
-      "num_split_features": 1
-    },
-    {
-      "first_letter": "c",
-      "absorption_rate": 0.09531502423263329,
-      "num_absorption": 59,
-      "num_probe_true_positives": 619,
-      "num_split_features": 2
-    },
-    {
-      "first_letter": "d",
-      "absorption_rate": 0.2356164383561644,
-      "num_absorption": 86,
-      "num_probe_true_positives": 365,
-      "num_split_features": 1
-    },
-    {
-      "first_letter": "e",
-      "absorption_rate": 0.18341708542713567,
-      "num_absorption": 73,
-      "num_probe_true_positives": 398,
-      "num_split_features": 1
-    },
-    {
-      "first_letter": "f",
-      "absorption_rate": 0.2597402597402597,
-      "num_absorption": 80,
-      "num_probe_true_positives": 308,
-      "num_split_features": 1
-    },
-    {
-      "first_letter": "g",
-      "absorption_rate": 0.2946859903381642,
-      "num_absorption": 61,
-      "num_probe_true_positives": 207,
-      "num_split_features": 1
-    },
-    {
-      "first_letter": "h",
-      "absorption_rate": 0.1937984496124031,
-      "num_absorption": 50,
-      "num_probe_true_positives": 258,
-      "num_split_features": 1
-    },
-    {
-      "first_letter": "i",
-      "absorption_rate": 0.013186813186813187,
-      "num_absorption": 6,
-      "num_probe_true_positives": 455,
-      "num_split_features": 1
-    },
-    {
-      "first_letter": "j",
-      "absorption_rate": 0.17857142857142858,
-      "num_absorption": 15,
-      "num_probe_true_positives": 84,
-      "num_split_features": 1
-    },
-    {
-      "first_letter": "k",
-      "absorption_rate": 0.11267605633802817,
-      "num_absorption": 8,
-      "num_probe_true_positives": 71,
-      "num_split_features": 1
-    },
-    {
-      "first_letter": "l",
-      "absorption_rate": 0.2932330827067669,
-      "num_absorption": 78,
-      "num_probe_true_positives": 266,
-      "num_split_features": 1
-    },
-    {
-      "first_letter": "m",
-      "absorption_rate": 0.20833333333333334,
-      "num_absorption": 70,
-      "num_probe_true_positives": 336,
-      "num_split_features": 1
-    },
-    {
-      "first_letter": "n",
-      "absorption_rate": 0.25609756097560976,
-      "num_absorption": 42,
-      "num_probe_true_positives": 164,
-      "num_split_features": 1
-    },
-    {
-      "first_letter": "o",
-      "absorption_rate": 0.125,
-      "num_absorption": 40,
+      "mean_absorption_fraction": 0.5422165839965818,
+      "full_absorption_rate": 0.1375,
+      "num_full_absorption": 44,
       "num_probe_true_positives": 320,
       "num_split_features": 1
     },
     {
+      "first_letter": "c",
+      "mean_absorption_fraction": 0.8390364307954514,
+      "full_absorption_rate": 0.28459119496855345,
+      "num_full_absorption": 181,
+      "num_probe_true_positives": 636,
+      "num_split_features": 2
+    },
+    {
+      "first_letter": "d",
+      "mean_absorption_fraction": 0.7216130923124239,
+      "full_absorption_rate": 0.34025974025974026,
+      "num_full_absorption": 131,
+      "num_probe_true_positives": 385,
+      "num_split_features": 1
+    },
+    {
+      "first_letter": "e",
+      "mean_absorption_fraction": 0.7607881640066256,
+      "full_absorption_rate": 0.18181818181818182,
+      "num_full_absorption": 72,
+      "num_probe_true_positives": 396,
+      "num_split_features": 1
+    },
+    {
+      "first_letter": "f",
+      "mean_absorption_fraction": 0.4649442719121791,
+      "full_absorption_rate": 0.2793103448275862,
+      "num_full_absorption": 81,
+      "num_probe_true_positives": 290,
+      "num_split_features": 1
+    },
+    {
+      "first_letter": "g",
+      "mean_absorption_fraction": 0.6676949061832219,
+      "full_absorption_rate": 0.16,
+      "num_full_absorption": 36,
+      "num_probe_true_positives": 225,
+      "num_split_features": 1
+    },
+    {
+      "first_letter": "h",
+      "mean_absorption_fraction": 0.6695205043837088,
+      "full_absorption_rate": 0.2591093117408907,
+      "num_full_absorption": 64,
+      "num_probe_true_positives": 247,
+      "num_split_features": 1
+    },
+    {
+      "first_letter": "i",
+      "mean_absorption_fraction": 0.7021534291778774,
+      "full_absorption_rate": 0.15894039735099338,
+      "num_full_absorption": 72,
+      "num_probe_true_positives": 453,
+      "num_split_features": 2
+    },
+    {
+      "first_letter": "j",
+      "mean_absorption_fraction": 0.5166195407113244,
+      "full_absorption_rate": 0.13043478260869565,
+      "num_full_absorption": 9,
+      "num_probe_true_positives": 69,
+      "num_split_features": 1
+    },
+    {
+      "first_letter": "k",
+      "mean_absorption_fraction": 0.4714207908589351,
+      "full_absorption_rate": 0.18604651162790697,
+      "num_full_absorption": 16,
+      "num_probe_true_positives": 86,
+      "num_split_features": 1
+    },
+    {
+      "first_letter": "l",
+      "mean_absorption_fraction": 0.7142741014762699,
+      "full_absorption_rate": 0.36328125,
+      "num_full_absorption": 93,
+      "num_probe_true_positives": 256,
+      "num_split_features": 1
+    },
+    {
+      "first_letter": "m",
+      "mean_absorption_fraction": 0.761914014066148,
+      "full_absorption_rate": 0.25142857142857145,
+      "num_full_absorption": 88,
+      "num_probe_true_positives": 350,
+      "num_split_features": 1
+    },
+    {
+      "first_letter": "n",
+      "mean_absorption_fraction": 0.8232207766223506,
+      "full_absorption_rate": 0.3128834355828221,
+      "num_full_absorption": 51,
+      "num_probe_true_positives": 163,
+      "num_split_features": 3
+    },
+    {
+      "first_letter": "o",
+      "mean_absorption_fraction": 0.5610040631894193,
+      "full_absorption_rate": 0.2118380062305296,
+      "num_full_absorption": 68,
+      "num_probe_true_positives": 321,
+      "num_split_features": 1
+    },
+    {
       "first_letter": "p",
-      "absorption_rate": 0.20696324951644102,
-      "num_absorption": 107,
-      "num_probe_true_positives": 517,
+      "mean_absorption_fraction": 0.8450834136670967,
+      "full_absorption_rate": 0.2692307692307692,
+      "num_full_absorption": 133,
+      "num_probe_true_positives": 494,
       "num_split_features": 1
     },
     {
       "first_letter": "q",
-      "absorption_rate": 0.17777777777777778,
-      "num_absorption": 8,
-      "num_probe_true_positives": 45,
+      "mean_absorption_fraction": 0.834943875860344,
+      "full_absorption_rate": 0.4444444444444444,
+      "num_full_absorption": 16,
+      "num_probe_true_positives": 36,
       "num_split_features": 1
     },
     {
       "first_letter": "r",
-      "absorption_rate": 0.2575,
-      "num_absorption": 103,
-      "num_probe_true_positives": 400,
-      "num_split_features": 2
+      "mean_absorption_fraction": 0.6164445161426998,
+      "full_absorption_rate": 0.4239401496259352,
+      "num_full_absorption": 170,
+      "num_probe_true_positives": 401,
+      "num_split_features": 1
     },
     {
       "first_letter": "s",
-      "absorption_rate": 0.13333333333333333,
-      "num_absorption": 80,
-      "num_probe_true_positives": 600,
+      "mean_absorption_fraction": 0.8475312419675276,
+      "full_absorption_rate": 0.23548387096774193,
+      "num_full_absorption": 146,
+      "num_probe_true_positives": 620,
       "num_split_features": 1
     },
     {
       "first_letter": "t",
-      "absorption_rate": 0.1661721068249258,
-      "num_absorption": 56,
-      "num_probe_true_positives": 337,
+      "mean_absorption_fraction": 0.6667360528021395,
+      "full_absorption_rate": 0.2687074829931973,
+      "num_full_absorption": 79,
+      "num_probe_true_positives": 294,
       "num_split_features": 1
     },
     {
       "first_letter": "u",
-      "absorption_rate": 0.15217391304347827,
-      "num_absorption": 28,
-      "num_probe_true_positives": 184,
-      "num_split_features": 1
-    },
-    {
-      "first_letter": "v",
-      "absorption_rate": 0.14912280701754385,
-      "num_absorption": 17,
-      "num_probe_true_positives": 114,
+      "mean_absorption_fraction": 0.5164139754174144,
+      "full_absorption_rate": 0.31351351351351353,
+      "num_full_absorption": 58,
+      "num_probe_true_positives": 185,
       "num_split_features": 2
     },
     {
+      "first_letter": "v",
+      "mean_absorption_fraction": 0.35070340846991804,
+      "full_absorption_rate": 0.12213740458015267,
+      "num_full_absorption": 16,
+      "num_probe_true_positives": 131,
+      "num_split_features": 1
+    },
+    {
       "first_letter": "w",
-      "absorption_rate": 0.24352331606217617,
-      "num_absorption": 47,
-      "num_probe_true_positives": 193,
+      "mean_absorption_fraction": 0.6397495844131196,
+      "full_absorption_rate": 0.34355828220858897,
+      "num_full_absorption": 56,
+      "num_probe_true_positives": 163,
       "num_split_features": 1
     },
     {
       "first_letter": "x",
-      "absorption_rate": 0.13333333333333333,
-      "num_absorption": 2,
-      "num_probe_true_positives": 15,
+      "mean_absorption_fraction": 0.33622823862686474,
+      "full_absorption_rate": 0.0,
+      "num_full_absorption": 0,
+      "num_probe_true_positives": 14,
       "num_split_features": 1
     },
     {
       "first_letter": "y",
-      "absorption_rate": 0.3953488372093023,
-      "num_absorption": 17,
-      "num_probe_true_positives": 43,
+      "mean_absorption_fraction": 0.8118688551758014,
+      "full_absorption_rate": 0.5142857142857142,
+      "num_full_absorption": 18,
+      "num_probe_true_positives": 35,
       "num_split_features": 1
     },
     {
       "first_letter": "z",
-      "absorption_rate": 0.24,
-      "num_absorption": 6,
-      "num_probe_true_positives": 25,
+      "mean_absorption_fraction": 0.5240333919455636,
+      "full_absorption_rate": 0.15,
+      "num_full_absorption": 3,
+      "num_probe_true_positives": 20,
       "num_split_features": 1
     }
   ],
-  "sae_bench_commit_hash": "5f1cf15d3f5edfe126be2d93d8a52c9e7a585755",
+  "sae_bench_commit_hash": "3a099d28607f73d3b816ded300591b86ae42d1b6",
   "sae_lens_id": "blocks.4.hook_resid_post__trainer_10",
-  "sae_lens_release_id": "sae_bench_pythia70m_sweep_standard_ctx128_0712",
-  "sae_lens_version": "4.0.9"
+  "sae_lens_release_id": "sae_bench_pythia70m_sweep_topk_ctx128_0730",
+  "sae_lens_version": "5.3.0",
+  "sae_cfg_dict": {
+    "architecture": "standard",
+    "d_in": 512,
+    "d_sae": 16384,
+    "activation_fn_str": "topk",
+    "apply_b_dec_to_input": true,
+    "finetuning_scaling_factor": false,
+    "context_size": 128,
+    "model_name": "pythia-70m-deduped",
+    "hook_name": "blocks.4.hook_resid_post",
+    "hook_layer": 4,
+    "hook_head_index": null,
+    "prepend_bos": true,
+    "dataset_path": "monology/pile-uncopyrighted",
+    "dataset_trust_remote_code": true,
+    "normalize_activations": "none",
+    "dtype": "torch.float32",
+    "device": "cuda",
+    "sae_lens_training_version": null,
+    "activation_fn_kwargs": {
+      "k": 80
+    },
+    "neuronpedia_id": "pythia-70m-deduped/4-sae_bench-topk-res-16k__trainer_10_step_final",
+    "model_from_pretrained_kwargs": {},
+    "seqpos_slice": [
+      null
+    ]
+  },
+  "eval_result_unstructured": null
 }

--- a/tests/unit/evals/absorption/test_feature_absorption.py
+++ b/tests/unit/evals/absorption/test_feature_absorption.py
@@ -55,5 +55,6 @@ def test_calculate_projection_and_cos_sims_gives_sane_results(
         "projection_feats",
         "projection_feat_acts",
         "projection_feat_probe_cos",
-        "is_absorption",
+        "absorption_fraction",
+        "is_full_absorption",
     ]


### PR DESCRIPTION
Adds a more general absorption metric alongside the existing one.

The existing metric has the following limitations:
- only detects full absorption (where the absorbed latents don't activate at all)
- only detects absorption cases where a single absorbing latent is mainly responsible for absorbing the main latents for the feature in question

Manual inspection revealed frequent cases where absorption had clearly occurred but wasn't detected by the existing metric due to the above limitations. The new metric addresses this by capturing both full and partial absorption with an arbitrary number of absorbing latents.

Initial results show that the two metrics sometimes differ in their relative rankings of models' absorption scores. We also observed that the new metric better handles SAEs with high L0s, which often got perfect or near perfect absorption scores under the old metric despite suffering from substantial absorption because the absorbed latents would usually still have small non-zero activations.

Also fixes a couple of bugs which may affect scores under the existing metric for some SAEs, though the differences have been small for the SAEs we've tested so far.