### PR TITLE
hide stddev from default display for absorption

### DIFF
--- a/sae_bench/evals/absorption/eval_output.py
+++ b/sae_bench/evals/absorption/eval_output.py
@@ -34,17 +34,14 @@ class AbsorptionMeanMetrics(BaseMetrics):
     std_dev_absorption_fraction_score: float = Field(
         title="Standard Deviation of Absorption Fraction Score",
         description="Standard deviation of the absorption fraction scores across all letters",
-        json_schema_extra=DEFAULT_DISPLAY,
     )
     std_dev_full_absorption_score: float = Field(
         title="Standard Deviation of Full Absorption Score",
         description="Standard deviation of the full absorption scores across all letters",
-        json_schema_extra=DEFAULT_DISPLAY,
     )
     std_dev_num_split_features: float = Field(
         title="Standard Deviation of Number of Split Features",
         description="Standard deviation of the number of split features across all letters",
-        json_schema_extra=DEFAULT_DISPLAY,
     )
 
 

--- a/sae_bench/evals/absorption/eval_output_schema_absorption_first_letter.json
+++ b/sae_bench/evals/absorption/eval_output_schema_absorption_first_letter.json
@@ -95,20 +95,17 @@
         "std_dev_absorption_fraction_score": {
           "description": "Standard deviation of the absorption fraction scores across all letters",
           "title": "Standard Deviation of Absorption Fraction Score",
-          "type": "number",
-          "ui_default_display": true
+          "type": "number"
         },
         "std_dev_full_absorption_score": {
           "description": "Standard deviation of the full absorption scores across all letters",
           "title": "Standard Deviation of Full Absorption Score",
-          "type": "number",
-          "ui_default_display": true
+          "type": "number"
         },
         "std_dev_num_split_features": {
           "description": "Standard deviation of the number of split features across all letters",
           "title": "Standard Deviation of Number of Split Features",
-          "type": "number",
-          "ui_default_display": true
+          "type": "number"
         }
       },
       "required": [


### PR DESCRIPTION
as per Can's request, hiding stddev from default display for absorption