### PR TITLE
chore: fixing linting errors and adding precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.9.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright
+        entry: poetry run pyright
+        language: system
+        types: [python]
+        require_serial: true

--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ If you use VSCode, install the Ruff plugin, and add the following to your `.vsco
 }
 ```
 
+### Pre-commit hook
+
+There's a pre-commit hook that will run ruff and pyright on each commit. To install it, run:
+
+```bash
+poetry run pre-commit install
+```
+
 ### Updating Eval Output Schemas
 
 Eval output structures / data types are under the `eval_output.py` file in each eval directory. If any of the `eval_output.py` files are updated, it's a good idea to run `python sae_bench/evals/generate_json_schemas.py` to make the json schemas match them as well.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ nbstripout = ">=0.7.1"
 loguru = ">=0.7.0"
 ruff = "^0.9.2"
 pyright = "^1.1.392.post0"
+pre-commit = "^4.1.0"
 
 [tool.pyright]
 typeCheckingMode = "standard"

--- a/sae_bench/custom_saes/run_all_evals_custom_saes.py
+++ b/sae_bench/custom_saes/run_all_evals_custom_saes.py
@@ -1,6 +1,7 @@
 import os
 from typing import Any
 
+import torch
 from tqdm import tqdm
 
 import sae_bench.evals.absorption.main as absorption
@@ -181,8 +182,12 @@ def run_evals(
                 continue
             print("Skipping, need to clean up unlearning interface")
             continue  # TODO:
-            if not os.path.exists("./sae_bench/evals/unlearning/data/bio-forget-corpus.jsonl"):
-                print("Skipping unlearning evaluation due to missing bio-forget-corpus.jsonl")
+            if not os.path.exists(
+                "./sae_bench/evals/unlearning/data/bio-forget-corpus.jsonl"
+            ):
+                print(
+                    "Skipping unlearning evaluation due to missing bio-forget-corpus.jsonl"
+                )
                 continue
 
         print(f"\n\n\nRunning {eval_type} evaluation\n\n\n")
@@ -228,8 +233,12 @@ if __name__ == "__main__":
         api_key = None
 
     if "unlearning" in eval_types:
-        if not os.path.exists("./sae_bench/evals/unlearning/data/bio-forget-corpus.jsonl"):
-            raise Exception("Please download bio-forget-corpus.jsonl for unlearning evaluation")
+        if not os.path.exists(
+            "./sae_bench/evals/unlearning/data/bio-forget-corpus.jsonl"
+        ):
+            raise Exception(
+                "Please download bio-forget-corpus.jsonl for unlearning evaluation"
+            )
 
     # If evaluating multiple SAEs on the same layer, set save_activations to True
     # This will require at least 100GB of disk space
@@ -240,7 +249,7 @@ if __name__ == "__main__":
             d_model,
             model_name,
             hook_layer,
-            device=device,
+            device=torch.device(device),
             dtype=general_utils.str_to_dtype(llm_dtype),
         )  # type: ignore
         selected_saes = [(f"{model_name}_layer_{hook_layer}_identity_sae", sae)]

--- a/sae_bench/sae_bench_utils/graphing_utils.py
+++ b/sae_bench/sae_bench_utils/graphing_utils.py
@@ -180,9 +180,7 @@ def plot_results(
         baseline_value = None
         assert baseline_label is None, "Please do not provide a label for the baseline"
 
-    title_3var = f"{title_prefix}L0 vs Loss Recovered vs {custom_metric_name}"
-    title_2var = f"{title_prefix}L0 vs {custom_metric_name}"
-
+    # title_3var = f"{title_prefix}L0 vs Loss Recovered vs {custom_metric_name}"
     # plot_3var_graph(
     #     eval_results,
     #     title_3var,
@@ -191,6 +189,8 @@ def plot_results(
     #     output_filename=f"{image_base_name}_3var.png",
     #     trainer_markers=trainer_markers,
     # )
+
+    title_2var = f"{title_prefix}L0 vs {custom_metric_name}"
     fig = plot_2var_graph(
         eval_results,
         custom_metric,
@@ -237,7 +237,9 @@ def plot_best_of_ks_results(
     for sae in eval_results:
         eval_results[sae].update(core_results[sae])
 
-    custom_metric, custom_metric_name = get_custom_metric_key_and_name(results_path, dummy_k)
+    custom_metric, custom_metric_name = get_custom_metric_key_and_name(
+        results_path, dummy_k
+    )
 
     custom_metric = "best_custom_metric"
     custom_metric_name = custom_metric_name.replace(f"Top {dummy_k}", f"Best of {ks}")
@@ -290,7 +292,9 @@ def plot_best_of_ks_results(
     )
 
 
-def get_custom_metric_key_and_name(eval_path: str, k: int | None = None) -> tuple[str, str]:
+def get_custom_metric_key_and_name(
+    eval_path: str, k: int | None = None
+) -> tuple[str, str]:
     if "tpp" in eval_path:
         custom_metric = f"tpp_threshold_{k}_total_metric"
         custom_metric_name = f"TPP Top {k} Metric"
@@ -367,17 +371,27 @@ def get_eval_results(eval_filenames: list[str]) -> dict[str, dict]:
         results_key = filename.replace("_eval_results.json", "")
 
         if "tpp" in filepath:
-            eval_results[results_key] = single_sae_results["eval_result_metrics"]["tpp_metrics"]
+            eval_results[results_key] = single_sae_results["eval_result_metrics"][
+                "tpp_metrics"
+            ]
         elif "scr" in filepath:
-            eval_results[results_key] = single_sae_results["eval_result_metrics"]["scr_metrics"]
+            eval_results[results_key] = single_sae_results["eval_result_metrics"][
+                "scr_metrics"
+            ]
         elif "absorption" in filepath:
-            eval_results[results_key] = single_sae_results["eval_result_metrics"]["mean"]
+            eval_results[results_key] = single_sae_results["eval_result_metrics"][
+                "mean"
+            ]
         elif "autointerp" in filepath:
-            eval_results[results_key] = single_sae_results["eval_result_metrics"]["autointerp"]
+            eval_results[results_key] = single_sae_results["eval_result_metrics"][
+                "autointerp"
+            ]
         elif "sparse_probing" in filepath:
             eval_results[results_key] = single_sae_results["eval_result_metrics"]["sae"]
         elif "unlearning" in filepath:
-            eval_results[results_key] = single_sae_results["eval_result_metrics"]["unlearning"]
+            eval_results[results_key] = single_sae_results["eval_result_metrics"][
+                "unlearning"
+            ]
         elif "core" in filepath:
             # core has nested evaluation metrics, so we flatten them out here
             core_results = single_sae_results["eval_result_metrics"]
@@ -415,9 +429,9 @@ def get_core_results(core_filenames: list[str]) -> dict:
             single_sae_results = json.load(f)
 
         l0 = single_sae_results["eval_result_metrics"]["sparsity"]["l0"]
-        ce_score = single_sae_results["eval_result_metrics"]["model_performance_preservation"][
-            "ce_loss_score"
-        ]
+        ce_score = single_sae_results["eval_result_metrics"][
+            "model_performance_preservation"
+        ]["ce_loss_score"]
 
         filename = os.path.basename(filepath)
         results_key = filename.replace("_eval_results.json", "")
@@ -492,7 +506,9 @@ def plot_3var_graph(
     if not trainer_markers:
         trainer_markers = TRAINER_MARKERS
 
-    trainer_markers, _ = update_trainer_markers_and_colors(results, trainer_markers, TRAINER_COLORS)
+    trainer_markers, _ = update_trainer_markers_and_colors(
+        results, trainer_markers, TRAINER_COLORS
+    )
 
     # Extract data from results
     l0_values = [data[x_axis_key] for data in results.values()]
@@ -737,7 +753,9 @@ def plot_2var_graph(
     if baseline_value is not None:
         ax.axhline(baseline_value, color="red", linestyle="--", label=baseline_label)
         labels.append(baseline_label)
-        handles.append(Line2D([0], [0], color="red", linestyle="--", label=baseline_label))
+        handles.append(
+            Line2D([0], [0], color="red", linestyle="--", label=baseline_label)
+        )
 
     # Place legend outside the plot on the right
     ax.legend(handles, labels, loc="center left", bbox_to_anchor=(1, 0.5))
@@ -793,10 +811,14 @@ def plot_2var_graph_dict_size(
 
     # Get unique dict sizes present in the data while preserving order from possible_sizes
     unique_sizes = [
-        size for size in possible_sizes if size in set(v["d_sae"] for v in results.values())
+        size
+        for size in possible_sizes
+        if size in set(v["d_sae"] for v in results.values())
     ]
 
-    assert len(unique_sizes) <= len(colors), "Too many unique dictionary sizes for color map"
+    assert len(unique_sizes) <= len(colors), (
+        "Too many unique dictionary sizes for color map"
+    )
 
     size_to_color = {size: colors[i] for i, size in enumerate(unique_sizes)}
 
@@ -839,7 +861,9 @@ def plot_2var_graph_dict_size(
     if baseline_value:
         ax.axhline(baseline_value, color="red", linestyle="--", label=baseline_label)
         labels.append(baseline_label)
-        handles.append(Line2D([0], [0], color="red", linestyle="--", label=baseline_label))
+        handles.append(
+            Line2D([0], [0], color="red", linestyle="--", label=baseline_label)
+        )
 
     ax.legend(handles, labels, loc=legend_location)
 
@@ -879,7 +903,9 @@ def plot_steps_vs_average_diff(
     # Extract data from the dictionary
     for key, value in results_dict.items():
         # Extract trainer number from the key
-        trainer = key.split("/")[-1].split("_")[1]  # Assuming format like "trainer_1_..."
+        trainer = key.split("/")[-1].split("_")[
+            1
+        ]  # Assuming format like "trainer_1_..."
         layer = key.split("/")[-2].split("_")[-2]
 
         if "topk_ctx128" in key:
@@ -1076,7 +1102,9 @@ def plot_correlation_scatter(
     plt.title(title)
 
     # Add a trend line
-    sns.regplot(x=x_values, y=y_values, scatter=False, color="red", label=f"r = {r:.4f}")
+    sns.regplot(
+        x=x_values, y=y_values, scatter=False, color="red", label=f"r = {r:.4f}"
+    )
 
     plt.legend()
 


### PR DESCRIPTION
This PR fixes the current linting and formatting errors keeping CI on main from building, and adds a pre-commit hook to automatically run linting / formatting / type-checking on commit. This will make it less likely that code that fails CI checks will get pushed to main.

The pre-commit hook is optional, and can be installed with:

```
poetry run pre-commit install
```

You can also run all CI checks manually with `make check-ci` before pushing code to make sure all checks pass locally