### PR TITLE
feat: allow setting the artifacts path

### DIFF
--- a/sae_bench/evals/autointerp/main.py
+++ b/sae_bench/evals/autointerp/main.py
@@ -571,6 +571,7 @@ def run_eval(
     output_path: str,
     force_rerun: bool = False,
     save_logs_path: str | None = None,
+    artifacts_path: str = "artifacts",
 ) -> dict[str, Any]:
     """
     selected_saes is a list of either tuples of (sae_lens release, sae_lens id) or (sae_name, SAE object)
@@ -579,7 +580,6 @@ def run_eval(
     sae_lens_version = get_sae_lens_version()
     sae_bench_commit_hash = get_sae_bench_version()
 
-    artifacts_base_folder = "artifacts"
     os.makedirs(output_path, exist_ok=True)
 
     results_dict = {}
@@ -606,7 +606,7 @@ def run_eval(
             print(f"Skipping {sae_release}_{sae_id} as results already exist")
             continue
 
-        artifacts_folder = os.path.join(artifacts_base_folder, EVAL_TYPE_ID_AUTOINTERP)
+        artifacts_folder = os.path.join(artifacts_path, EVAL_TYPE_ID_AUTOINTERP)
 
         sae_eval_result = run_eval_single_sae(
             config, sae, model, device, artifacts_folder, api_key, sparsity
@@ -732,6 +732,12 @@ def arg_parser():
         help="Output folder",
     )
     parser.add_argument(
+        "--artifacts_path",
+        type=str,
+        default="artifacts",
+        help="Path to save artifacts",
+    )
+    parser.add_argument(
         "--force_rerun", action="store_true", help="Force rerun of experiments"
     )
     parser.add_argument(
@@ -790,6 +796,7 @@ if __name__ == "__main__":
         api_key,
         args.output_folder,
         args.force_rerun,
+        artifacts_path=args.artifacts_path,
     )
 
     end_time = time.time()

--- a/sae_bench/evals/scr_and_tpp/main.py
+++ b/sae_bench/evals/scr_and_tpp/main.py
@@ -763,6 +763,7 @@ def run_eval(
     force_rerun: bool = False,
     clean_up_activations: bool = False,
     save_activations: bool = True,
+    artifacts_path: str = "artifacts",
 ):
     """
     selected_saes is a list of either tuples of (sae_lens release, sae_lens id) or (sae_name, SAE object)
@@ -781,7 +782,6 @@ def run_eval(
     output_path = os.path.join(output_path, eval_type)
     os.makedirs(output_path, exist_ok=True)
 
-    artifacts_base_folder = "artifacts"
     artifacts_folder = None
 
     results_dict = {}
@@ -809,7 +809,7 @@ def run_eval(
             continue
 
         artifacts_folder = os.path.join(
-            artifacts_base_folder,
+            artifacts_path,
             eval_type,
             config.model_name,
             sae.cfg.hook_name,
@@ -964,6 +964,12 @@ def arg_parser():
         help="Output folder",
     )
     parser.add_argument(
+        "--artifacts_path",
+        type=str,
+        default="artifacts",
+        help="Path to save artifacts",
+    )
+    parser.add_argument(
         "--force_rerun", action="store_true", help="Force rerun of experiments"
     )
     parser.add_argument(
@@ -1060,6 +1066,7 @@ if __name__ == "__main__":
         args.force_rerun,
         args.clean_up_activations,
         args.save_activations,
+        artifacts_path=args.artifacts_path,
     )
 
     end_time = time.time()

--- a/sae_bench/evals/sparse_probing/main.py
+++ b/sae_bench/evals/sparse_probing/main.py
@@ -288,6 +288,7 @@ def run_eval(
     force_rerun: bool = False,
     clean_up_activations: bool = False,
     save_activations: bool = True,
+    artifacts_path: str = "artifacts",
 ):
     """
     selected_saes is a list of either tuples of (sae_lens release, sae_lens id) or (sae_name, SAE object)
@@ -299,7 +300,6 @@ def run_eval(
     sae_lens_version = get_sae_lens_version()
     sae_bench_commit_hash = get_sae_bench_version()
 
-    artifacts_base_folder = "artifacts"
     artifacts_folder = None
     os.makedirs(output_path, exist_ok=True)
 
@@ -328,7 +328,7 @@ def run_eval(
             continue
 
         artifacts_folder = os.path.join(
-            artifacts_base_folder,
+            artifacts_path,
             EVAL_TYPE_ID_SPARSE_PROBING,
             config.model_name,
             sae.cfg.hook_name,
@@ -492,6 +492,12 @@ def arg_parser():
         action="store_true",
         help="Lower GPU memory usage by doing more computation on the CPU. Useful on 1M width SAEs. Will be slower and require more system memory.",
     )
+    parser.add_argument(
+        "--artifacts_path",
+        type=str,
+        default="artifacts",
+        help="Path to save artifacts",
+    )
 
     return parser
 
@@ -526,6 +532,7 @@ if __name__ == "__main__":
         args.force_rerun,
         args.clean_up_activations,
         args.save_activations,
+        artifacts_path=args.artifacts_path,
     )
 
     end_time = time.time()

--- a/sae_bench/evals/unlearning/main.py
+++ b/sae_bench/evals/unlearning/main.py
@@ -114,6 +114,7 @@ def run_eval(
     output_path: str,
     force_rerun: bool = False,
     clean_up_artifacts: bool = False,
+    artifacts_path: str = "artifacts",
 ):
     """
     selected_saes is a list of either tuples of (sae_lens release, sae_lens id) or (sae_name, SAE object)
@@ -136,7 +137,7 @@ def run_eval(
 
     os.makedirs(output_path, exist_ok=True)
 
-    artifacts_folder = os.path.join("artifacts", EVAL_TYPE, config.model_name)
+    artifacts_folder = os.path.join(artifacts_path, EVAL_TYPE, config.model_name)
 
     results_dict = {}
 
@@ -288,6 +289,12 @@ def arg_parser():
         choices=[None, "float32", "float64", "float16", "bfloat16"],
         help="Data type for LLM. If None, will be populated using LLM_NAME_TO_DTYPE",
     )
+    parser.add_argument(
+        "--artifacts_path",
+        type=str,
+        default="artifacts",
+        help="Path to save artifacts",
+    )
 
     return parser
 
@@ -327,6 +334,7 @@ if __name__ == "__main__":
         args.output_folder,
         args.force_rerun,
         args.clean_up_artifacts,
+        args.artifacts_path,
     )
 
     end_time = time.time()


### PR DESCRIPTION
The SCR and TPP evals say it's important to use the same artifacts when comparing SAEs, but there's no way to set where the artifacts are saved making this challenging when running jobs on a cluster. This PR adds an `artifacts_path` option to the evals which use artifacts, specifically TPP/SCR, autointerp, and sparse probing.