### PR TITLE
WIP: Fix explained variance calculation

### DIFF
--- a/sae_bench/evals/core/eval_output.py
+++ b/sae_bench/evals/core/eval_output.py
@@ -69,14 +69,6 @@ class ReconstructionQualityMetrics(BaseMetrics):
         title="Cosine Similarity",
         description="Cosine similarity between original activation and SAE reconstruction",
     )
-    total_sum_of_squares: float = Field(
-        title="Total Sum of Squares",
-        description="Sum of squares of the original activation",
-    )
-    resid_sum_of_squares: float = Field(
-        title="Residual Sum of Squares",
-        description="Sum of squares of the residual between original activation and SAE reconstruction",
-    )
 
 
 # Define metrics for shrinkage

--- a/sae_bench/evals/core/eval_output.py
+++ b/sae_bench/evals/core/eval_output.py
@@ -69,6 +69,14 @@ class ReconstructionQualityMetrics(BaseMetrics):
         title="Cosine Similarity",
         description="Cosine similarity between original activation and SAE reconstruction",
     )
+    total_sum_of_squares: float = Field(
+        title="Total Sum of Squares",
+        description="Sum of squares of the original activation",
+    )
+    resid_sum_of_squares: float = Field(
+        title="Residual Sum of Squares",
+        description="Sum of squares of the residual between original activation and SAE reconstruction",
+    )
 
 
 # Define metrics for shrinkage

--- a/sae_bench/evals/core/main.py
+++ b/sae_bench/evals/core/main.py
@@ -238,6 +238,12 @@ def run_evals(
                     "explained_variance": sparsity_variance_metrics[
                         "explained_variance"
                     ],
+                    "total_sum_of_squares": sparsity_variance_metrics[
+                        "total_sum_of_squares"
+                    ],
+                    "resid_sum_of_squares": sparsity_variance_metrics[
+                        "resid_sum_of_squares"
+                    ],
                     "mse": sparsity_variance_metrics["mse"],
                     "cossim": sparsity_variance_metrics["cossim"],
                 }
@@ -463,6 +469,8 @@ def get_sparsity_and_variance_metrics(
         metric_dict["explained_variance"] = []
         metric_dict["mse"] = []
         metric_dict["cossim"] = []
+        metric_dict["total_sum_of_squares"] = []
+        metric_dict["resid_sum_of_squares"] = []
     if compute_featurewise_density_statistics:
         feature_metric_dict["feature_density"] = []
         feature_metric_dict["consistent_activation_heuristic"] = []
@@ -583,6 +591,8 @@ def get_sparsity_and_variance_metrics(
             cossim = (x_normed * x_hat_normed).sum(dim=-1)
 
             metric_dict["explained_variance"].append(explained_variance)
+            metric_dict["total_sum_of_squares"].append(total_sum_of_squares)
+            metric_dict["resid_sum_of_squares"].append(resid_sum_of_squares)
             metric_dict["mse"].append(mse)
             metric_dict["cossim"].append(cossim)
 


### PR DESCRIPTION
https://www.lesswrong.com/posts/ZBjhp6zwfE8o8yfni/stefanhex-s-shortform?commentId=95yixuEzraPh8mYTL

SAEBench is currently using this explained variance / fraction of variance unexplained (FVU) formula:
![image](https://github.com/user-attachments/assets/8470fdbc-0b53-4442-aa5e-7a9dc73b86be)

But this is the more sensible / conventional formula (e.g. Wikipedia [here](https://en.wikipedia.org/wiki/Coefficient_of_determination) and [here](https://en.wikipedia.org/wiki/Fraction_of_variance_unexplained)):
![image](https://github.com/user-attachments/assets/50f77463-a894-4670-a8d5-c9f4d69c90f5)

This PR changes the formula used in SAEBench. The implementation is a bit ugly because
1. The nominator and denominator need to be averaged separately
2. The mean technically needs to be computed over all samples, so we can't compute the explained variance in a batched fashion

The 1st point is the major effect, while the 2nd point was minor in my experience. In this PR I address both, but if memory usage is an issue then leaving out point 2 and computing `total_variance` and `residual_variance` in a batched fashion will be pretty close to the correct result (this is what I implemented in the first commit).

TODO: I'm just running a test to make sure the new implementation gives the expected results