### PR TITLE
Fix autointerp demo.py

### DIFF
--- a/sae_bench/evals/autointerp/demo.py
+++ b/sae_bench/evals/autointerp/demo.py
@@ -19,21 +19,23 @@ device = torch.device(
 selected_saes = [("gpt2-small-res-jb", "blocks.7.hook_resid_pre")]
 torch.set_grad_enabled(False)
 
-# ! Demo 1: just 4 specially chosen latents
-cfg = AutoInterpEvalConfig(model_name="gpt2-small", override_latents=[9, 11, 15, 16873])
+# ! Demo 1: just 4 specially chosen latents. Must specify n_latents=None explicitly. Also must specify llm_batch_size and llm_batch_size when not running from main.py.
+cfg = AutoInterpEvalConfig(model_name="gpt2-small", n_latents=None, override_latents=[9, 11, 15, 16873], llm_dtype="bfloat16", llm_batch_size=32)
 save_logs_path = Path(__file__).parent / "logs_4.txt"
 save_logs_path.unlink(missing_ok=True)
+output_path = Path(__file__).parent / "data"
+output_path.mkdir(exist_ok=True)
 results = run_eval(
-    cfg, selected_saes, str(device), api_key, save_logs_path=save_logs_path
+    cfg, selected_saes, str(device), api_key, output_path=output_path, save_logs_path=save_logs_path
 )  # type: ignore
 print(results)
 
 # ! Demo 2: 100 randomly chosen latents
-cfg = AutoInterpEvalConfig(model_name="gpt2-small", n_latents=100)
+cfg = AutoInterpEvalConfig(model_name="gpt2-small", n_latents=100, llm_dtype="bfloat16", llm_batch_size=32)
 save_logs_path = Path(__file__).parent / "logs_100.txt"
 save_logs_path.unlink(missing_ok=True)
 results = run_eval(
-    cfg, selected_saes, str(device), api_key, save_logs_path=save_logs_path
+    cfg, selected_saes, str(device), api_key, output_path=output_path, save_logs_path=save_logs_path
 )  # type: ignore
 print(results)
 

--- a/sae_bench/evals/autointerp/eval_config.py
+++ b/sae_bench/evals/autointerp/eval_config.py
@@ -39,7 +39,7 @@ class AutoInterpEvalConfig:
         title="Model Name",
         description="Model name. Must be set with a command line argument.",
     )
-    n_latents: int = Field(
+    n_latents: int | None = Field(
         default=1000,
         title="Number of Latents",
         description="The number of latents for the LLM judge to interpret",


### PR DESCRIPTION
Allow `n_latents` to be `None` in `AutoInterpEvalConfig` type definition so that `override_latents` argument will be used. `__post_init__` already ensures that either `n_latents` or `override_latents` must be `None`, so previously there was no way to actually specify `override_latents`. Pass additional arguments to `run_eval` in `demo.py` so that `demo.py` runs without needing to call `create_config_and_selected_saes()` within `main.py` (which is meant to be called from the command line).