### PR TITLE
Fix error messages

### DIFF
--- a/sae_bench/custom_saes/base_sae.py
+++ b/sae_bench/custom_saes/base_sae.py
@@ -54,12 +54,12 @@ class BaseSAE(nn.Module, ABC):
     @abstractmethod
     def decode(self, feature_acts: torch.Tensor):
         """Must be implemented by child classes"""
-        raise NotImplementedError("Encode method must be implemented by child classes")
+        raise NotImplementedError("Decode method must be implemented by child classes")
 
     @abstractmethod
     def forward(self, x: torch.Tensor):
         """Must be implemented by child classes"""
-        raise NotImplementedError("Encode method must be implemented by child classes")
+        raise NotImplementedError("Forward method must be implemented by child classes")
 
     def to(self, *args, **kwargs):
         """Handle device and dtype updates"""


### PR DESCRIPTION
Fixed incorrect error messages in ```decode```, and ```forward``` methods. 
The previous messages for ```decode``` and ```forward``` mistakenly referenced the encode method. 
Updated them to match the actual method names for better clarity.