### PR TITLE
GT probe f1 score threshold to check valid features for absorption calculation

### DIFF
--- a/sae_bench/evals/absorption/eval_config.py
+++ b/sae_bench/evals/absorption/eval_config.py
@@ -66,3 +66,14 @@ class AbsorptionEvalConfig(BaseEvalConfig):
         title="K-Sparse Probe Number of Epochs",
         description="Number of epochs for k-sparse probes.",
     )
+    min_GT_probe_f1: float = Field(
+        default=0.6,
+        title="Minimum ground truth probe F1 score",
+        description="The minimum ground truth probe F1 score for the first-letter feature to be considered present",
+    )
+    min_feats_for_eval: int = Field(
+        default=20,
+        ge=1,
+        title="Minumum features for evaluation",
+        description="The minimum number of first-letter features (as detected by the GT probes) needed to evaluate absorption",
+    )

--- a/tests/acceptance/test_absorption.py
+++ b/tests/acceptance/test_absorption.py
@@ -44,6 +44,7 @@ def test_end_to_end_different_seed():
         prompt_token_pos=-6,
         llm_batch_size=512,
         llm_dtype="float32",
+        min_GT_probe_f1=0.3,
     )
     selected_saes = get_saes_from_regex(TEST_RELEASE, TEST_SAE_NAME)
     print(f"Selected SAEs: {selected_saes}")


### PR DESCRIPTION
If the model doesn't have some first-letter features linearly represented at the layer in question then we shouldn't use them in our absorption evaluation because the scores will be misleading.

This PR addresses this with the following changes:

- first-letter features must have ground truth probe f1 scores above a configurable threshold to be used for evaluating absorption.   Absorption scores on features with f1 scores below the threshold will be ignored in the final absorption metrics.
- If there are less than min_feats_for_eval many valid features according to the above criteria then we will skip evaluating absorption for SAEs with this model/layer since any reported score (including zero) could be misleading.