### PR TITLE
Fix mistral tokenization

### DIFF
--- a/sae_bench/evals/absorption/feature_absorption_calculator.py
+++ b/sae_bench/evals/absorption/feature_absorption_calculator.py
@@ -63,6 +63,8 @@ class FeatureAbsorptionCalculator:
     answer_formatter: Formatter = first_letter_formatter()
     example_separator: str = "\n"
     shuffle_examples: bool = True
+    # Mistral tokenizer handles the first token incorrectly if we don't do this
+    prepend_separator_to_first_example: bool = True
     # the position to read activations from (depends on the template)
     word_token_pos: int = -2
     batch_size: int = 10
@@ -87,6 +89,7 @@ class FeatureAbsorptionCalculator:
                 example_separator=self.example_separator,
                 max_icl_examples=self.max_icl_examples,
                 shuffle_examples=self.shuffle_examples,
+                prepend_separator_to_first_example=self.prepend_separator_to_first_example,
             )
             for word in words
         ]

--- a/sae_bench/evals/absorption/probing.py
+++ b/sae_bench/evals/absorption/probing.py
@@ -254,6 +254,8 @@ def create_dataset_probe_training(
     answer_class_fn: Callable[[str], int] = lambda answer: LETTERS.index(
         answer.strip().lower()
     ),
+    # Mistral tokenizer handles the first token incorrectly if we don't do this
+    prepend_separator_to_first_example: bool = True,
 ) -> tuple[list[tuple[SpellingPrompt, int]], list[tuple[SpellingPrompt, int]]]:
     """
     Create train and test datasets for probe training by generating prompts for each token in the given vocabulary.
@@ -292,6 +294,7 @@ def create_dataset_probe_training(
                     answer_formatter=formatter,
                     base_template=base_template,
                     max_icl_examples=max_icl_examples,
+                    prepend_separator_to_first_example=prepend_separator_to_first_example,
                 )
                 answer_class = answer_class_fn(prompt.answer)
                 prompts_list.append((prompt, answer_class))

--- a/sae_bench/evals/absorption/prompting.py
+++ b/sae_bench/evals/absorption/prompting.py
@@ -79,6 +79,7 @@ def create_icl_prompt(
     shuffle_examples: bool = True,
     check_contamination: bool = True,
     max_attempts: int = 1000,
+    prepend_separator_to_first_example: bool = False,
 ) -> SpellingPrompt:
     """
     Create a prompt with ICL examples in the base, optionally checking for contamination.
@@ -93,6 +94,7 @@ def create_icl_prompt(
         shuffle_examples: whether to shuffle the examples before selecting the first `max_icl_examples`. default is True
         check_contamination: whether to check and prevent the current word from appearing in ICL examples. default is True
         max_attempts: maximum number of attempts to avoid contamination before raising an exception. default is 1000
+        prepend_separator_to_first_example: whether to prepend the example separator to the first example. default is False
     """
     if max_icl_examples is None:
         max_icl_examples = len(examples)
@@ -129,8 +131,12 @@ def create_icl_prompt(
     word_answer = answer_formatter(word)
     word_base = base_template.format(word=word)
 
+    base = example_separator.join(icl_prompts) + example_separator + word_base
+    if prepend_separator_to_first_example:
+        base = example_separator + base
+
     return SpellingPrompt(
-        base=example_separator.join(icl_prompts) + example_separator + word_base,
+        base=base,
         answer=word_answer,
         word=word,
     )
@@ -142,6 +148,7 @@ def random_icl_prompt(
     example_separator: str = "\n",
     answer_formatter: Formatter = first_letter_formatter(),
     max_icl_examples: int = 10,
+    prepend_separator_to_first_example: bool = False,
 ) -> SpellingPrompt:
     return create_icl_prompt(
         word=random.choice(vocab),
@@ -150,4 +157,5 @@ def random_icl_prompt(
         example_separator=example_separator,
         answer_formatter=answer_formatter,
         max_icl_examples=max_icl_examples,
+        prepend_separator_to_first_example=prepend_separator_to_first_example,
     )

--- a/sae_bench/evals/absorption/vocab.py
+++ b/sae_bench/evals/absorption/vocab.py
@@ -14,10 +14,23 @@ def get_tokens(
 ) -> list[str]:
     result = []
     for token in tokenizer.vocab.keys():
-        word = tokenizer.convert_tokens_to_string([token])
+        word = convert_tokens_to_string(token, tokenizer)
         if filter(word):
             result.append(word if replace_special_chars else token)
     return result
+
+
+def convert_tokens_to_string(token: str, tokenizer: PreTrainedTokenizerFast) -> str:
+    converted = tokenizer.convert_tokens_to_string([token])
+    # special case for mistral tokenizer's broken handling of leading space tokens
+    # see: https://github.com/adamkarvonen/SAEBench/issues/68#issuecomment-2794621999
+    if (
+        len(token) > 0
+        and token[0] == "▁"
+        and (len(converted) == 0 or converted[0] != " ")
+    ):
+        converted = " " + converted
+    return converted
 
 
 def get_alpha_tokens(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 from sae_lens import SAE
 from transformer_lens import HookedTransformer
-from transformers import GPT2LMHeadModel
+from transformers import AutoTokenizer, GPT2LMHeadModel
 
 
 @pytest.fixture
@@ -13,6 +13,13 @@ def gpt2_model():
 @pytest.fixture
 def gpt2_tokenizer(gpt2_model: HookedTransformer):
     return gpt2_model.tokenizer
+
+
+@pytest.fixture
+def fake_mistral_tokenizer():
+    # This seems to work the same as the mistral tokenizer, but we can't load the
+    # real mistral tokenizer in tests since it's gated.
+    return AutoTokenizer.from_pretrained("hf-internal-testing/llama-tokenizer")
 
 
 @pytest.fixture

--- a/tests/unit/evals/absorption/test_prompting.py
+++ b/tests/unit/evals/absorption/test_prompting.py
@@ -115,3 +115,50 @@ def test_create_icl_prompt_avoids_contamination():
         f"Expected {max_icl_examples} examples, "
         f"but found {len(icl_examples_in_prompt)}."
     )
+
+
+def test_create_icl_prompt_with_prepended_separator():
+    prompt = create_icl_prompt(
+        "cat",
+        examples=["dog", "bird"],
+        shuffle_examples=False,
+        prepend_separator_to_first_example=True,
+    )
+
+    expected_base = """
+        dog: D
+        bird: B
+        cat:"""
+    assert prompt.base == "\n" + dedent(expected_base).strip()
+    assert prompt.word == "cat"
+    assert prompt.answer == " C"
+
+
+def test_create_icl_prompt_with_custom_separator_prepended():
+    prompt = create_icl_prompt(
+        "cat",
+        examples=["dog", "bird"],
+        shuffle_examples=False,
+        example_separator=" | ",
+        prepend_separator_to_first_example=True,
+    )
+
+    expected_base = " | dog: D | bird: B | cat:"
+    assert prompt.base == expected_base
+    assert prompt.word == "cat"
+    assert prompt.answer == " C"
+
+
+def test_create_icl_prompt_no_separator_prepending_by_default():
+    prompt = create_icl_prompt(
+        "cat",
+        examples=["dog", "bird"],
+        shuffle_examples=False,
+    )
+
+    expected_base = """dog: D
+        bird: B
+        cat:"""
+    assert prompt.base.replace(" ", "") == expected_base.replace(" ", "")
+    assert prompt.word == "cat"
+    assert prompt.answer == " C"

--- a/tests/unit/evals/absorption/test_vocab.py
+++ b/tests/unit/evals/absorption/test_vocab.py
@@ -1,8 +1,9 @@
-from transformers import GPT2TokenizerFast
+from transformers import GPT2TokenizerFast, LlamaTokenizerFast
 
 from sae_bench.evals.absorption.vocab import (
     LETTERS,
     LETTERS_UPPER,
+    convert_tokens_to_string,
     get_alpha_tokens,
     get_tokens,
 )
@@ -58,3 +59,11 @@ def test_get_alpha_tokens_can_remove_leading_spaces(
         gpt2_tokenizer, allow_leading_space=False, replace_special_chars=True
     )
     assert all(token.isalpha() for token in alpha_tokens)
+
+
+def test_convert_tokens_to_string_works_with_mistral_tokenizer(
+    fake_mistral_tokenizer: LlamaTokenizerFast,
+):
+    token = "▁hello"
+    converted = convert_tokens_to_string(token, fake_mistral_tokenizer)
+    assert converted == " hello"


### PR DESCRIPTION
This PR fixes a bug with the absorption benchmark for mistral, where tokens with leading spaces are not being detected properly.

It also turns out that mistral always inserts a space before the first token at the start of a sequence, so this often causes the first token to not be correct. To try to correct for this, this PR now adds a newline as the first character of all prompts. This is a bit strange, and hopefully shouldn't dramatically change any results on other models by much, but does seem to hackily fix the benchmark for mistral. Alternatively, we could make this a param that's set in the absorption config, but might be confusing to communicate to users.

fixes #68 