### PR TITLE
fix: pinning saelens to v5.x.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = ["Topic :: Scientific/Engineering :: Artificial Intelligence"]
 
 [tool.poetry.dependencies]
 python = "^3.10,"
-sae_lens = ">=5.4.0"
+sae_lens = "^5.4.0"
 transformer-lens = ">=2.0.0"
 torch = ">=2.1.0"
 einops = ">=0.8.0"

--- a/sae_bench/evals/ravel/generation.py
+++ b/sae_bench/evals/ravel/generation.py
@@ -76,7 +76,7 @@ def generate_batched(
             attention_mask=attention_mask,
             max_new_tokens=max_new_tokens,
             do_sample=False,  # greedy decoding for reproducibility
-        )
+        )  # type: ignore
         generated_ids = output_ids[:, -max_new_tokens:]
         generations.append(generated_ids)
 

--- a/sae_bench/evals/ravel/intervention.py
+++ b/sae_bench/evals/ravel/intervention.py
@@ -120,7 +120,7 @@ def generate_batched_interventions(
             ),
             max_new_tokens=max_new_tokens,
             do_sample=False,  # greedy decoding for reproducibility
-        )
+        )  # type: ignore
 
         handle.remove()
         generated_ids = output_ids[:, -max_new_tokens:]


### PR DESCRIPTION
This PR pins SAELens to be v5. SAELens v6 will be released soon and will include a breaking change to `SAE.from_pretrained()` that will likely break SAEbench. This PR just pins the current SAEBench to SAELens v5 for now, and a new version of SAEBench can be pushed later for v6+