### PR TITLE
chore: update semantic-release action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           python-version: "3.11"
       - name: Semantic Release
         id: release
-        uses: python-semantic-release/python-semantic-release@v8.0.7
+        uses: python-semantic-release/python-semantic-release@v9.8.8
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish package distributions to PyPI


### PR DESCRIPTION
It looks like the semantic release action is failing on main (https://github.com/adamkarvonen/SAEBench/actions/runs/18448540177/job/52558912351). This PR updates the version of the semantic-release github action, which should hopefully fix things.